### PR TITLE
Bugfix/udon asmdef error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fixed udon asmdef reference. [`#108`](https://github.com/niwaniwa/KineLVideoPlayer/issues/108)
 - Fixed PlaylistAPI URL. [`#109`](https://github.com/niwaniwa/KineLVideoPlayer/issues/109)
 
 ### Removed

--- a/Packages/la.niri.videoplayer/Runtime/Udon/Kinel.VideoPlayer.Udon.asset
+++ b/Packages/la.niri.videoplayer/Runtime/Udon/Kinel.VideoPlayer.Udon.asset
@@ -12,5 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5136146375e9a0a498a72a0091b40cc1, type: 3}
   m_Name: Kinel.VideoPlayer.Udon
   m_EditorClassIdentifier: 
-  sourceAssembly: {fileID: 5897886265953266890, guid: f2d732cb19e49d341a9b0db5e649283f,
+  sourceAssembly: {fileID: 5897886265953266890, guid: 5a2e9b84b363c8049957b83d6125f47e,
     type: 3}


### PR DESCRIPTION
# 概要
VPM化に伴う階層変更によってudon asmdefの参照が切れていた問題を修正

このUpdateの後、v2.5.1にUpdateする

resolve #108