### PR TITLE
fix: 解像度変更時ã、非プレイ時にもReload：してしまう問題を修正

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - UI 向け MSDF シェーダ (`Kinel/MSDF`) で `_ClipRect` 未宣言によりコンパイルエラーが発生する問題を修正 ([#145](https://github.com/niwaniwa/KineLVideoPlayer/issues/145))
 - PlaylistのEditorにおいてTrackを手入力しようとしたときに正しく値が反映されない問題を修正 [#152](https://github.com/niwaniwa/KineLVideoPlayer/issues/152)
+- 解像度設定変更時、プレイしていない状況でもReloadされてしまう問題を修正 [#149](https://github.com/niwaniwa/KineLVideoPlayer/issues/149)
 
 ### Security
 

--- a/v3/Runtime/Udon/System/KinelPlayerController.cs
+++ b/v3/Runtime/Udon/System/KinelPlayerController.cs
@@ -8,8 +8,6 @@ namespace Kinel.VideoPlayer.V3.Udon.System
 {
     public class KinelPlayerController : KinelVideoListener
     {
-        // UDONSYNCEDは分離する -> to KinelVariableSyncer
-
         [SerializeField] private KinelMediaBase[] mediaModule;
         [SerializeField] private AudioSource audioSource;
         [SerializeField] private KinelMediaType nowSelectedType;
@@ -87,11 +85,15 @@ namespace Kinel.VideoPlayer.V3.Udon.System
 
         public void SetResolution(int resolution)
         {
-            var url = NowSelectedMediaModule.SourceUrl;
-            if (url != null && !url.Equals(VRCUrl.Empty))
+            if (IsPlaying())
             {
-                _isReloading = true;
+                var url = NowSelectedMediaModule.SourceUrl;
+                if (url != null && !url.Equals(VRCUrl.Empty))
+                {
+                    _isReloading = true;
+                }
             }
+
             NowSelectedMediaModule.SetResolution(resolution);
         }
 
@@ -151,6 +153,7 @@ namespace Kinel.VideoPlayer.V3.Udon.System
             {
                 SendCustomEventDelayedFrames(nameof(_ClearReloading), 1);
             }
+
             foreach (var listener in Listeners)
             {
                 listener.OnKinelVideoStart();
@@ -381,6 +384,7 @@ namespace Kinel.VideoPlayer.V3.Udon.System
                 NowSelectedMediaModule.ReloadMedia();
                 return;
             }
+
             _isReloading = true;
             _retryCount = 0;
             _lastLoadedUrl = url;

--- a/v3/Runtime/Udon/System/KinelVideoPlayerHandler.cs
+++ b/v3/Runtime/Udon/System/KinelVideoPlayerHandler.cs
@@ -130,6 +130,8 @@ namespace Kinel.VideoPlayer.V3.Udon.System
             this.resolution = Mathf.Clamp(resolution, 1, 8);
             Log($"Resolution Changed: {this.resolution}");
             if (_animator != null) _animator.SetInteger(resolutionAnimatorFlag, this.resolution);
+            
+            if (!IsPlaying()) return;
             ReloadMedia();
         }
 


### PR DESCRIPTION
# Fix
closes: #149 
- 解像度設定変更時、プレイしていない状況でもReloadされてしまう問題を修正 [#149](https://github.com/niwaniwa/KineLVideoPlayer/issues/149) 