### PR TITLE
Fix: UI非表示時にPlaylistなどのアイテムを押せてしまうことで意図しない動作になってしまう問題を修正

### DIFF
--- a/CHANGELOG-PRERELEASE.md
+++ b/CHANGELOG-PRERELEASE.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- UIを非表示時に、PlaylistのUIなどを押せてしまい誤動作してしまう問題を修正 [#161](https://github.com/niwaniwa/KineLVideoPlayer/issues/161)
 
 ### Security
 

--- a/v3/KineLVideoPlayer-v3.prefab
+++ b/v3/KineLVideoPlayer-v3.prefab
@@ -83,6 +83,7 @@ MonoBehaviour:
     SerializationNodes: []
   _udonSharpBackingUdonBehaviour: {fileID: 6282711038126326205}
   debugMode: 1
+  controller: {fileID: 0}
   playlistIdentifyName: Playlist
   playlistNames:
   - Playlist 2
@@ -6142,7 +6143,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 615, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &45160666570646468
@@ -6350,6 +6351,7 @@ MonoBehaviour:
   nowSelectedType: 0
   maxRetryCount: 3
   retryIntervalSeconds: 5
+  _initialLoopMode: 0
 --- !u!114 &3463823080124285783
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -13750,6 +13752,10 @@ MonoBehaviour:
   previousButton: {fileID: 0}
   nextButton: {fileID: 0}
   loopToggleButton: {fileID: 9113541791645474856}
+  loopButtonIcon: {fileID: 0}
+  loopNoneSprite: {fileID: 0}
+  loopSingleSprite: {fileID: 0}
+  loopPlaylistSprite: {fileID: 0}
   volumeMute: {fileID: 8862558663759685109}
   volumeUnMute: {fileID: 3461968591310365176}
   volumeZero: {fileID: 6978942416556437629}
@@ -13797,6 +13803,7 @@ MonoBehaviour:
   queueAddButton: {fileID: 7173512108880685786}
   errorTextMesh: {fileID: 7668157660322814850}
   seekTimeIncrement: 10
+  _playlistSelectorOffset: 1
   queueObject: {fileID: 8050934947994025105}
   queueListUIContent: {fileID: 2906082469101728839}
 --- !u!114 &6283820813940229110
@@ -16272,6 +16279,7 @@ RectTransform:
   m_LocalScale: {x: 0.0009999999, y: 0.0009999999, z: 0.0009999999}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 8988920377696990634}
   - {fileID: 2456357582946149302}
   - {fileID: 3616675469419058977}
   - {fileID: 8370542598612218188}
@@ -16926,7 +16934,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 2456357582946149302}
+  m_Father: {fileID: 4602312755245723738}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -18560,7 +18568,6 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8988920377696990634}
   - {fileID: 6190379065868867046}
   - {fileID: 9210309680714248557}
   - {fileID: 3692045861511538213}

--- a/v3/Runtime/Assets/Animations/Menu Off.anim
+++ b/v3/Runtime/Assets/Animations/Menu Off.anim
@@ -38,6 +38,27 @@ AnimationClip:
     classID: 225
     script: {fileID: 0}
     flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Interactable
+    path: Root
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
   m_PPtrCurves: []
   m_SampleRate: 60
   m_WrapMode: 0
@@ -46,6 +67,15 @@ AnimationClip:
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
     genericBindings:
+    - serializedVersion: 2
+      path: 3066451557
+      attribute: 4287062452
+      script: {fileID: 0}
+      typeID: 225
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
     - serializedVersion: 2
       path: 3066451557
       attribute: 1574349066
@@ -94,6 +124,27 @@ AnimationClip:
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_Alpha
+    path: Root
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Interactable
     path: Root
     classID: 225
     script: {fileID: 0}

--- a/v3/Runtime/Assets/Animations/Menu On.anim
+++ b/v3/Runtime/Assets/Animations/Menu On.anim
@@ -38,6 +38,27 @@ AnimationClip:
     classID: 225
     script: {fileID: 0}
     flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Interactable
+    path: Root
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
   m_PPtrCurves: []
   m_SampleRate: 60
   m_WrapMode: 0
@@ -46,6 +67,15 @@ AnimationClip:
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
     genericBindings:
+    - serializedVersion: 2
+      path: 3066451557
+      attribute: 4287062452
+      script: {fileID: 0}
+      typeID: 225
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
     - serializedVersion: 2
       path: 3066451557
       attribute: 1574349066
@@ -94,6 +124,27 @@ AnimationClip:
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_Alpha
+    path: Root
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Interactable
     path: Root
     classID: 225
     script: {fileID: 0}

--- a/v3/Runtime/KinelVideoPlayer-V3.unity
+++ b/v3/Runtime/KinelVideoPlayer-V3.unity
@@ -5047,6 +5047,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 816314834437228909, guid: 777e2769aed4414da3005f8bd03e17ae, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 979283743431795058, guid: 777e2769aed4414da3005f8bd03e17ae, type: 3}
       propertyPath: serializedProgramAsset
       value: 


### PR DESCRIPTION
# 概要
UI非表示時にPlaylistなどのアイテムを押せてしまうことで意図しない動作になってしまう問題を修正

# 方法
- RootのCanvasGrounpに付与されているinteractableとblock raycastを組み合わせて無効化